### PR TITLE
Added recursive constructor option to allow for reviver functions

### DIFF
--- a/lib/json_object.dart
+++ b/lib/json_object.dart
@@ -29,9 +29,6 @@ void _log(obj) {
  */
 @proxy
 class JsonObject<E> extends Object implements Map, Iterable  {
-  /// The original JSON string
-  var _jsonString;
-
   /// Contains either a [List] or [Map]
   var _objectData;
   
@@ -99,8 +96,7 @@ class JsonObject<E> extends Object implements Map, Iterable  {
     if (t == null) {
       t = new JsonObject();
     }
-    t._jsonString = _jsonString;
-    t._objectData = decoder.convert(t._jsonString);
+    t._objectData = decoder.convert(_jsonString);
     t._extractElements(t._objectData);
     t.isExtendable = false;
     return t;
@@ -111,14 +107,12 @@ class JsonObject<E> extends Object implements Map, Iterable  {
    * rather than a json string.
    */
   JsonObject.fromMap(Map map) {
-    _jsonString = encoder.convert(map);
     _objectData = map;
     _extractElements(_objectData);
     isExtendable = false;
   }
 
   static JsonObject toTypedJsonObject(JsonObject src, JsonObject dest) {
-    dest._jsonString = src._jsonString;
     dest._objectData = src._objectData;
     dest.isExtendable = false;
     return dest;

--- a/lib/json_object.dart
+++ b/lib/json_object.dart
@@ -263,14 +263,14 @@ class JsonObject<E> extends Object implements Map, Iterable  {
 
   @deprecated
   E firstMatching(bool test(E value), { E orElse() : null }) {
-    if (orElse != null) this.toIterable().firstWhere(test, orElse: orElse);
-    else this.toIterable().firstWhere(test);
+    if (orElse != null) return this.toIterable().firstWhere(test, orElse: orElse);
+    else return this.toIterable().firstWhere(test);
   }
 
   @deprecated
   E lastMatching(bool test(E value), {E orElse() : null}) {
-    if (orElse != null) this.toIterable().lastWhere(test, orElse: orElse);
-    else this.toIterable().lastWhere(test);
+    if (orElse != null) return this.toIterable().lastWhere(test, orElse: orElse);
+    else return this.toIterable().lastWhere(test);
   }
 
   @deprecated

--- a/lib/json_object.dart
+++ b/lib/json_object.dart
@@ -105,10 +105,14 @@ class JsonObject<E> extends Object implements Map, Iterable  {
 
   /** An alternate constructor, allows creating directly from a map
    * rather than a json string.
+   *
+   * If [recursive] is true, all values of the map will be converted
+   * to [JsonObject]s as well. The default value is [true].
    */
-  JsonObject.fromMap(Map map) {
+  JsonObject.fromMap(Map map, [bool recursive = true]) {
     _objectData = map;
-    _extractElements(_objectData);
+    if(recursive)
+      _extractElements(_objectData);
     isExtendable = false;
   }
 


### PR DESCRIPTION
I accidentally made this PR from my master branch, so I made an additional commit from it. However, both changed are very minor and do not break anything.

First: the field `_jsonString` holds the stringified version of the object, but it is never used. The `toString()` method uses the `JsonEncoder`. So I deleted this field.

Second: `JsonDecoder` allows for the use of a reviver-method. This way, people can convert json objects to their own classes. The fact that `JsonObject` always recursively converts all underlying data to `JsonObject`s, breaks reviver functionality. So I added an optional `bool recursive` parameter to `JsonObject.fromMap` to allow for the usage of revivers along with `JsonObject`. I use it myself and it works just fine.